### PR TITLE
Detect AdBlock Plus extension again

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adblock-detect-react",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Provides utilities to check if ad block is enabled on a page via both a React hook and a wrapper component.",
   "main": "cjs/index.js",
   "module": "esm/index.js",

--- a/src/hooks/useDetectAdBlock.ts
+++ b/src/hooks/useDetectAdBlock.ts
@@ -7,7 +7,7 @@ export const useDetectAdBlock = () => {
     const adToDetect = document.createElement("div");
     adToDetect.setAttribute(
       "class",
-      "pub_300x250 pub_300x250m pub_728x90 text-ad textAd text_ad text_ads text-ads text-ad-links"
+      "googlead pub_300x250 pub_300x250m pub_728x90 text-ad textAd text_ad text_ads text-ads text-ad-links"
     );
     adToDetect.setAttribute(
       "style",


### PR DESCRIPTION
The provided ad honeypots are somehow whitelisted by [Adblock Plus](https://chrome.google.com/webstore/detail/adblock-plus-free-ad-bloc/cfhdojbkjhnklbpkdaibdccddilifddb?hl=de) extension. Adding another one `googlead` lets the hook detect Adblock Plus extension again.