### PR TITLE
Fix to detect uBlock Origin

### DIFF
--- a/adblock-detect-react/src/hooks/useDetectAdBlock.ts
+++ b/adblock-detect-react/src/hooks/useDetectAdBlock.ts
@@ -10,7 +10,10 @@ export const useDetectAdBlock = () => {
       method: "HEAD",
       mode: "no-cors",
       cache: "no-store",
-    }).catch(() => {
+    }).then(({ redirected }) => {
+      if (redirected) setAdBlockDetected(true);
+    })
+      .catch(() => {
       setAdBlockDetected(true);
     });
   }, []);


### PR DESCRIPTION
uBlock Origin doesn't "block" calls, but redirects them with a 307 redirect. So the request will never fail. This way, the catch block will never run, and `adBlockDetected` will never be true.

With my changes, the request will check if the responses is redirected. If so, set adBlockDetected to true.
